### PR TITLE
fix: 修改获取载货量百分比时的颜色范围

### DIFF
--- a/auto/run_business/buy.py
+++ b/auto/run_business/buy.py
@@ -152,7 +152,7 @@ def get_boatload():
         获取载货量百分比
     """
     image = screenshot()
-    lower_color_bound = np.array([36, 36, 36])
+    lower_color_bound = np.array([35, 35, 35])
     upper_color_bound = np.array([36, 36, 36])
 
     y = 418


### PR DESCRIPTION
可能是游戏的问题，range([36, 36, 36], [36, 36, 36])的颜色范围对我无效，我的载货量进度条中的黑色部分rgb为[35, 36, 35]。
具体如下：
![example](https://github.com/Night-stars-1/Auto_Resonance/assets/51394793/9c10eb4e-d766-48e3-b9a5-bb2db50b4b08)
将取色范围修改为range([35, 35, 35], [36, 36, 36])后有效。